### PR TITLE
Removed some redundant keys

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -195,10 +195,6 @@ csharp_style_implicit_object_creation_when_type_is_apparent = true:warning
 # "Null" checking preferences
 csharp_style_throw_expression = true:warning
 csharp_style_conditional_delegate_call = true:warning
-# Code block preferences
-csharp_prefer_braces = true:warning
-csharp_prefer_simple_using_statement = true:suggestion
-dotnet_diagnostic.IDE0063.severity = suggestion
 # 'using' directive preferences
 csharp_using_directive_placement = inside_namespace:warning
 # Modifier preferences


### PR DESCRIPTION
There were a couple redundant key/values. If you happened to modify only one of a key then there is a chance the value of the other definition was used over your modification!