### PR TITLE
fix: use LF newlines for powershell

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -88,14 +88,6 @@ indent_size = 2
 [*.{cmd,bat}]
 end_of_line = crlf
 
-# Powershell Files
-[*.ps1]
-end_of_line = crlf
-
-# Bash Files
-[*.sh]
-end_of_line = lf
-
 # Makefiles
 [Makefile]
 indent_style = tab


### PR DESCRIPTION
Updated line endings for powershell since it can be used on non-MS platforms. Also removed duplicate LF line-ending spec for shell scripts.